### PR TITLE
Fix Fuel URI in new_dvl world

### DIFF
--- a/models/dave_worlds/worlds/new_dvl.world
+++ b/models/dave_worlds/worlds/new_dvl.world
@@ -83,7 +83,7 @@
 		<!-- Virtual north, east and down frame -->
 		<include>
 			<uri>
-				https://fuel.gazebosim.org/1.0/hmoyen/models/North-East-Down frame
+				https://fuel.gazebosim.org/1.0/hmoyen/models/North East Down frame
 			</uri>
 			<pose>0 0 0 0 0 0</pose>
 		</include>


### PR DESCRIPTION
## Summary

Fix the Fuel model URI used by `new_dvl.world` for the virtual North-East-Down frame.

The world referenced `North-East-Down frame`, but the published Fuel model is named `North East Down frame`. The malformed URI returns HTTP 404 and Gazebo reports `Error Code 14`, preventing the world from loading normally.

## Change

```diff
- https://fuel.gazebosim.org/1.0/hmoyen/models/North-East-Down frame
+ https://fuel.gazebosim.org/1.0/hmoyen/models/North East Down frame
```

This also makes `new_dvl.world` consistent with the other DAVE worlds that use the same model.

## Reproduction

```bash
curl -L -o /dev/null -sS -w '%{http_code}\n' \
  'https://fuel.gazebosim.org/1.0/hmoyen/models/North-East-Down%20frame'
# 404
```

A Gazebo launch with the original world reports:

```text
Failed to download model.
REST response code: 404
Error Code 14: Unable to find uri[.../North-East-Down frame]
```

## Validation

```bash
curl -L -o /dev/null -sS -w '%{http_code}\n' \
  'https://fuel.gazebosim.org/1.0/hmoyen/models/North%20East%20Down%20frame'
# 200

xmllint --noout models/dave_worlds/worlds/new_dvl.world
pre-commit run --files models/dave_worlds/worlds/new_dvl.world
```

The corrected world was also launched in an ARM64 Docker environment with ROS 2 Lyrical and Gazebo Jetty:

```bash
ros2 launch dave_demos dave_sensor.launch.py \
  namespace:=dvl world_name:=new_dvl paused:=false \
  gui:=true headless:=false
```

Observed after the change:

- world create request completed successfully
- Gazebo `/dvl/velocity` payload received
- ROS `/dvl/velocity` payload received
- simulation iterations advanced
- no Fuel URI or fatal signature was observed

## Checklist

- [x] The change is limited to one issue.
- [x] XML validation passed.
- [x] Repository pre-commit hooks passed for the changed file.
- [x] The corrected Fuel resource was verified and the world was re-run.
