### PR TITLE
Guard DVL bridge spin during ROS shutdown

### DIFF
--- a/gazebo/dave_ros_gz_plugins/src/DVLBridge.cc
+++ b/gazebo/dave_ros_gz_plugins/src/DVLBridge.cc
@@ -183,14 +183,30 @@ void DVLBridge::receiveGazeboCallback(const gz::msgs::DVLVelocityTracking & msg)
 void DVLBridge::PostUpdate(
   const gz::sim::UpdateInfo & _info, const gz::sim::EntityComponentManager & _ecm)
 {
-  if (!_info.paused)
+  if (_info.paused || !this->ros_node_ || !rclcpp::ok())
+  {
+    return;
+  }
+
+  try
   {
     rclcpp::spin_some(this->ros_node_);
-
-    if (_info.iterations % 1000 == 0)
+  }
+  catch (const rclcpp::exceptions::RCLError & error)
+  {
+    // SIGINT can invalidate the global context between the ok() check and
+    // temporary executor construction inside rclcpp::spin_some().
+    if (rclcpp::ok())
     {
-      gzmsg << "dave_ros_gz_plugins::DVLBridge::PostUpdate" << std::endl;
+      throw;
     }
+    gzdbg << "Skipping DVL ROS spin during shutdown: " << error.what() << std::endl;
+    return;
+  }
+
+  if (_info.iterations % 1000 == 0)
+  {
+    gzmsg << "dave_ros_gz_plugins::DVLBridge::PostUpdate" << std::endl;
   }
 }
 


### PR DESCRIPTION
## Summary

Prevent `DVLBridge::PostUpdate()` from calling `rclcpp::spin_some()` after the ROS context has been invalidated during shutdown.

## Problem

When Gazebo receives `SIGINT`, the ROS context can be shut down while the simulation update thread is still entering `PostUpdate()`. The current implementation unconditionally calls `rclcpp::spin_some()` whenever the simulation is not paused.

In the reproduced failure, `spin_some()` attempted to construct a temporary executor after the context had become invalid. The resulting `rclcpp::exceptions::RCLError` was uncaught and aborted the Gazebo server:

```text
terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
what(): failed to create guard condition: the given context is not valid,
either rcl_init() was not called or rcl_shutdown() was called
...
rclcpp::spin_some(...)
dave_ros_gz_plugins::DVLBridge::PostUpdate(...)
Aborted
```

## Change

- Return early when the simulation is paused, the node is unavailable, or the ROS context is no longer valid.
- Catch the race where the context becomes invalid between the `rclcpp::ok()` check and executor construction in `spin_some()`.
- Re-throw `RCLError` when the context is still valid, so unrelated runtime errors are not hidden.

This does not change DVL message conversion or the public interface.

## Reproduction

Launch a world containing `DVLBridge`, confirm DVL messages, and stop the server with `SIGINT`. Repeat the launch and shutdown several times:

```bash
ros2 launch dave_demos dave_sensor.launch.py \
  namespace:=dvl world_name:=new_dvl paused:=false \
  gui:=true headless:=false
# Confirm /dvl/velocity, then press Ctrl-C. Repeat.
```

The stock bridge reproduced one shutdown abort in three trials. The failing process exited with code 134 from `DVLBridge::PostUpdate()`.

## Validation

The exact candidate source in this PR was built and tested in an ARM64 Docker environment with ROS 2 Lyrical and Gazebo Jetty.

| Result | Stock bridge | Patched bridge |
| --- | ---: | ---: |
| Trials | 3 | 10 |
| Server ready | 3/3 | 10/10 |
| Gazebo DVL payload | 3/3 | 10/10 |
| ROS DVL payload | 2/3 | 10/10 |
| Advancing simulation stats | 3/3 | 10/10 |
| Clean shutdown | 2/3 | 10/10 |
| Abort / fatal signature | 1/3 | 0/10 |

Repository checks:

```bash
pre-commit run --files gazebo/dave_ros_gz_plugins/src/DVLBridge.cc
# Passed, including clang-format

git diff --check
# Passed
```

## Checklist

- [x] The change is limited to the DVL bridge shutdown race.
- [x] Normal-context exceptions remain visible.
- [x] DVL payload behavior was checked before shutdown.
- [x] Repeated shutdown testing passed with the candidate.
- [x] Repository formatting hooks passed.
