### PR TITLE
Fix underwater camera red and blue channel mapping

### DIFF
--- a/gazebo/dave_gz_sensor_plugins/src/UnderwaterCamera.cc
+++ b/gazebo/dave_gz_sensor_plugins/src/UnderwaterCamera.cc
@@ -224,11 +224,11 @@ void UnderwaterCamera::Configure(
 
   if (!_sdf->HasElement("attenuationR"))
   {
-    this->dataPtr->attenuation[0] = 1.f / 30.f;
+    this->dataPtr->attenuation[2] = 1.f / 30.f;
   }
   else
   {
-    this->dataPtr->attenuation[0] = _sdf->Get<float>("attenuationR");
+    this->dataPtr->attenuation[2] = _sdf->Get<float>("attenuationR");
   }
 
   if (!_sdf->HasElement("attenuationG"))
@@ -242,20 +242,20 @@ void UnderwaterCamera::Configure(
 
   if (!_sdf->HasElement("attenuationB"))
   {
-    this->dataPtr->attenuation[2] = 1.f / 30.f;
+    this->dataPtr->attenuation[0] = 1.f / 30.f;
   }
   else
   {
-    this->dataPtr->attenuation[2] = _sdf->Get<float>("attenuationB");
+    this->dataPtr->attenuation[0] = _sdf->Get<float>("attenuationB");
   }
 
   if (!_sdf->HasElement("backgroundR"))
   {
-    this->dataPtr->background[0] = (unsigned char)0;
+    this->dataPtr->background[2] = (unsigned char)0;
   }
   else
   {
-    this->dataPtr->background[0] = (unsigned char)_sdf->Get<int>("backgroundR");
+    this->dataPtr->background[2] = (unsigned char)_sdf->Get<int>("backgroundR");
   }
 
   if (!_sdf->HasElement("backgroundG"))
@@ -269,11 +269,11 @@ void UnderwaterCamera::Configure(
 
   if (!_sdf->HasElement("backgroundB"))
   {
-    this->dataPtr->background[2] = (unsigned char)0;
+    this->dataPtr->background[0] = (unsigned char)0;
   }
   else
   {
-    this->dataPtr->background[2] = (unsigned char)_sdf->Get<int>("backgroundB");
+    this->dataPtr->background[0] = (unsigned char)_sdf->Get<int>("backgroundB");
   }
 
   // Gazebo camera subscriber


### PR DESCRIPTION
## Summary

Map the underwater camera's red and blue SDF parameters to the correct OpenCV BGR channel indices.

## Problem

`UnderwaterCamera` converts incoming RGB images to BGR before applying attenuation and background values. However, `attenuationR` / `backgroundR` were stored at index `0`, while `attenuationB` / `backgroundB` were stored at index `2`.

For an OpenCV `cv::Vec3b` image, index `0` is blue and index `2` is red. As a result, changing a red-tagged SDF parameter affected blue pixels and changing a blue-tagged parameter affected red pixels.

## Change

- Store `attenuationR` and `backgroundR` at BGR index `2`.
- Store `attenuationB` and `backgroundB` at BGR index `0`.
- Keep green at index `1`.

The image message format and SDF parameter names are unchanged.

## Reproduction

Run the underwater camera with one parameter changed at a time:

- `attenuationR` only
- `attenuationG` only
- `attenuationB` only
- `backgroundR` only
- `backgroundG` only
- `backgroundB` only

With the original mapping, the red-only conditions modify the blue image channel and the blue-only conditions modify the red channel.

## Validation

The candidate was tested with eight simultaneous streams in a controlled planar scene:

1. control
2. common attenuation baseline
3. red-only attenuation
4. green-only attenuation
5. blue-only attenuation
6. red-only background
7. green-only background
8. blue-only background

Results after the change:

- each attenuation tag changed only its named RGB channel
- each background tag changed only its named RGB channel
- all eight streams produced distinct frames
- all streams produced 10 captured frames
- measured center pixels matched the analytical BGR expectation exactly
- maximum center-pixel error: **0 LSB**

This validates the per-channel transform and tag mapping in the controlled scene; it does not claim general physical underwater optical accuracy.

Repository checks:

```bash
pre-commit run --files gazebo/dave_gz_sensor_plugins/src/UnderwaterCamera.cc
# Passed, including clang-format

git diff --check
# Passed
```

## Checklist

- [x] The change is limited to the red/blue semantic mapping.
- [x] SDF and message interfaces remain unchanged.
- [x] All six channel-isolation conditions were validated.
- [x] Repository formatting hooks passed.
