### PR TITLE
Declare configured IMU topics in vehicle models

### DIFF
--- a/models/dave_robot_models/description/bluerov2/model.sdf
+++ b/models/dave_robot_models/description/bluerov2/model.sdf
@@ -45,6 +45,7 @@
         <pose>0 0 0 3.142 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
+        <topic>/model/bluerov2/imu</topic>
       </sensor>
 
     </link>

--- a/models/dave_robot_models/description/bluerov2_heavy/model.sdf
+++ b/models/dave_robot_models/description/bluerov2_heavy/model.sdf
@@ -45,6 +45,7 @@
         <pose>0 0 0 3.142 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
+        <topic>/model/bluerov2_heavy/imu</topic>
       </sensor>
 
     </link>

--- a/models/dave_robot_models/description/bluerov2_heavy_multibeam_sonar/model.sdf
+++ b/models/dave_robot_models/description/bluerov2_heavy_multibeam_sonar/model.sdf
@@ -45,6 +45,7 @@
         <pose>0 0 0 3.142 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
+        <topic>/model/bluerov2_heavy_multibeam_sonar/imu</topic>
       </sensor>
 
     </link>

--- a/models/dave_robot_models/description/glider_slocum/model.sdf
+++ b/models/dave_robot_models/description/glider_slocum/model.sdf
@@ -57,6 +57,7 @@
       <sensor name="imu_sensor" type="imu">
         <always_on>true</always_on>
         <update_rate>50.0</update_rate>
+        <topic>/model/glider_slocum/imu</topic>
       </sensor>
     </link>
 

--- a/models/dave_robot_models/description/rexrov/model.sdf
+++ b/models/dave_robot_models/description/rexrov/model.sdf
@@ -189,6 +189,7 @@
       <sensor name="imu_sensor" type="imu">
         <always_on>true</always_on>
         <update_rate>50.0</update_rate>
+        <topic>/model/rexrov/imu</topic>
       </sensor>
     </link>
 


### PR DESCRIPTION
## Summary

Declare the IMU sensor topic expected by each vehicle's `ros_gz_bridge` configuration.

## Problem

The five vehicle descriptors contain an IMU sensor but do not set its `<topic>`. Gazebo therefore publishes IMU data on an automatically generated sensor path such as:

```text
/world/.../model/<vehicle>/link/.../sensor/imu_sensor/imu
```

The corresponding `robot_config.py` files bridge a different, stable topic:

```text
/model/<vehicle>/imu
```

The ROS bridge endpoint is created, but it receives no messages because no Gazebo publisher exists on the configured topic.

## Change

Add the configured IMU topic to these model descriptors:

- `bluerov2`
- `bluerov2_heavy`
- `bluerov2_heavy_multibeam_sonar`
- `glider_slocum`
- `rexrov`

No bridge names, message types, update rates, poses, or sensor parameters are changed.

## Reproduction

Launch a vehicle and compare the configured topic with the Gazebo sensor topics:

```bash
ros2 launch dave_demos dave_robot.launch.py \
  namespace:=bluerov2 world_name:=dave_ocean_waves \
  paused:=false gui:=true headless:=true \
  use_ardusub:=false use_teleop:=false

gz topic -l | grep imu
ros2 topic echo /model/bluerov2/imu --once
```

Before the change, the default Gazebo sensor path publishes data while the configured short topic remains silent.

## Validation

The topic correction was checked across all five affected descriptors:

- `rexrov`: the patched run received all seven expected state/sensor streams, including IMU
- `glider_slocum`: the patched run received all six expected state/sensor streams, including IMU
- `bluerov2`: IMU payload received on `/model/bluerov2/imu`
- `bluerov2_heavy`: IMU payload received on `/model/bluerov2_heavy/imu`
- `bluerov2_heavy_multibeam_sonar`: a fresh ARM64 Docker run received an IMU payload on `/model/bluerov2_heavy_multibeam_sonar/imu`; the message contained orientation, angular velocity, and linear acceleration fields

The unpatched BlueROV sensor-contract run also confirmed that the default Gazebo IMU path had real data while all three configured short-name IMU topics were silent.

Repository checks:

```bash
pre-commit run --files \
  models/dave_robot_models/description/bluerov2/model.sdf \
  models/dave_robot_models/description/bluerov2_heavy/model.sdf \
  models/dave_robot_models/description/bluerov2_heavy_multibeam_sonar/model.sdf \
  models/dave_robot_models/description/glider_slocum/model.sdf \
  models/dave_robot_models/description/rexrov/model.sdf
# Passed

git diff --check
# Passed
```

## Checklist

- [x] The change is limited to the missing IMU topic declarations.
- [x] Each topic matches its existing bridge configuration.
- [x] All five affected vehicle variants have runtime evidence.
- [x] Repository hooks passed.
