### PR TITLE
Set explicit ArduSub simulation speedup

### DIFF
--- a/models/dave_robot_models/config/bluerov2/robot_config.py
+++ b/models/dave_robot_models/config/bluerov2/robot_config.py
@@ -78,6 +78,8 @@ def launch_setup(context, *args, **kwargs):
     ardusub_process = ExecuteProcess(
         cmd=[
             "ardusub",
+            "--speedup",
+            "1",
             "-w",
             "--model",
             ardusub_model,

--- a/models/dave_robot_models/config/bluerov2_heavy/robot_config.py
+++ b/models/dave_robot_models/config/bluerov2_heavy/robot_config.py
@@ -144,6 +144,8 @@ def launch_setup(context, *args, **kwargs):
     ardusub_process = ExecuteProcess(
         cmd=[
             "ardusub",
+            "--speedup",
+            "1",
             "-w",
             "--model",
             ardusub_model,

--- a/models/dave_robot_models/config/bluerov2_heavy_multibeam_sonar/robot_config.py
+++ b/models/dave_robot_models/config/bluerov2_heavy_multibeam_sonar/robot_config.py
@@ -138,6 +138,8 @@ def launch_setup(context, *args, **kwargs):
     ardusub_process = ExecuteProcess(
         cmd=[
             "ardusub",
+            "--speedup",
+            "1",
             "-w",
             "--model",
             ardusub_model,


### PR DESCRIPTION
## Summary

Pass an explicit `--speedup 1` argument when DAVE starts ArduSub for all three BlueROV2 configurations.

## Problem

In the tested ARM64 SITL build, starting `ardusub` without an explicit speedup left `SIM_SPEEDUP` at `-1`. After Gazebo JSON sensor input started, ArduSub terminated with `SIGFPE` in `AP_Logger_File::periodic_1Hz()`.

GDB placed the exception in the logger path. The relevant ArduPilot code multiplies an unsigned timeout by the SITL speedup value, so the negative default creates an invalid boundary in this environment.

```text
Thread 1 "ardusub" received signal SIGFPE, Arithmetic exception.
AP_Logger_File::periodic_1Hz()
```

## Change

Add the explicit real-time speed factor to the existing ArduSub command:

```text
ardusub --speedup 1 ...
```

The change is applied consistently to:

- `bluerov2`
- `bluerov2_heavy`
- `bluerov2_heavy_multibeam_sonar`

No vehicle parameters, controller settings, or bridge interfaces are changed.

## Reproduction

Launch any of the BlueROV2 variants with ArduSub enabled and wait for the Gazebo JSON connection:

```bash
ros2 launch dave_demos dave_robot.launch.py \
  namespace:=bluerov2 world_name:=dave_ocean_waves \
  paused:=false gui:=true headless:=true use_ardusub:=true
```

The reproduced baseline received JSON sensor data and then raised `SIGFPE` in the ArduSub logger.

## Validation

The candidate was installed into the DAVE ARM64 Docker environment with ROS 2 Lyrical and Gazebo Jetty. Each BlueROV2 variant completed one bounded headless control run:

| Variant | JSON input | MAVROS samples | Armed | 6 s control response | Disarmed | ArduSub FPE |
| --- | --- | --- | --- | --- | --- | --- |
| `bluerov2` | PASS | 4/4 connected | PASS | +1.698 m X | PASS | 0 |
| `bluerov2_heavy` | PASS | 4/4 connected | PASS | +1.126 m X | PASS | 0 |
| `bluerov2_heavy_multibeam_sonar` | PASS | 4/4 connected | PASS | +0.819 m X | PASS | 0 |

These results establish the simulated JSON/MAVROS/control connection in the tested environment. They do not establish controller tuning, physical safety, or real-vehicle accuracy.

Repository checks:

```bash
python3 -m py_compile \
  models/dave_robot_models/config/bluerov2/robot_config.py \
  models/dave_robot_models/config/bluerov2_heavy/robot_config.py \
  models/dave_robot_models/config/bluerov2_heavy_multibeam_sonar/robot_config.py

pre-commit run --files <the three robot_config.py files>
# Passed

git diff --check
# Passed
```

## Checklist

- [x] The change is limited to the ArduSub speedup argument.
- [x] All three modified Python files compile.
- [x] All three BlueROV2 variants completed a bounded control run.
- [x] Repository hooks passed.
