### PR TITLE
Fix SeaPressure output units

### DIFF
--- a/gazebo/dave_gz_sensor_plugins/src/sea_pressure_sensor.cc
+++ b/gazebo/dave_gz_sensor_plugins/src/sea_pressure_sensor.cc
@@ -214,10 +214,17 @@ void SubseaPressureSensorPlugin::PostUpdate(
 {
   this->dataPtr->lastMeasurementTime = _info.simTime;
 
+  // The pressure model uses kPa internally, while both Gazebo and ROS
+  // FluidPressure messages require Pa (and Pa^2 for variance).
+  constexpr double kPaToPa = 1000.0;
+  const double pressurePa = this->dataPtr->pressure * kPaToPa;
+  const double variancePa2 =
+    this->dataPtr->noiseSigma * this->dataPtr->noiseSigma * kPaToPa * kPaToPa;
+
   // Publishing Sea_Pressure and depth estimate on gazebo topic
   gz::msgs::FluidPressure gzPressureMsg;
-  gzPressureMsg.set_pressure(this->dataPtr->pressure);
-  gzPressureMsg.set_variance(this->dataPtr->noiseSigma * this->dataPtr->noiseSigma);
+  gzPressureMsg.set_pressure(pressurePa);
+  gzPressureMsg.set_variance(variancePa2);
 
   // Publishing the pressure message
   this->dataPtr->gz_pressure_sensor_pub.Publish(gzPressureMsg);
@@ -229,8 +236,8 @@ void SubseaPressureSensorPlugin::PostUpdate(
   rosPressureMsg.header.stamp.nanosec =
     std::chrono::duration_cast<std::chrono::nanoseconds>(_info.simTime).count() %
     1000000000;  // Time in nanoseconds
-  rosPressureMsg.fluid_pressure = this->dataPtr->pressure;
-  rosPressureMsg.variance = this->dataPtr->noiseSigma * this->dataPtr->noiseSigma;
+  rosPressureMsg.fluid_pressure = pressurePa;
+  rosPressureMsg.variance = variancePa2;
   this->dataPtr->ros_pressure_sensor_pub->publish(rosPressureMsg);
 
   // publishing depth message


### PR DESCRIPTION
## Summary

Publish DAVE SeaPressure readings in the SI units required by both Gazebo and ROS `FluidPressure` messages.

## Problem

The sensor model computes pressure internally in kPa:

```text
surface: 101.325 kPa
depth 10 m: 101.325 + 10 * 9.80638 = 199.3888 kPa
```

The plugin serialized those values unchanged. Runtime capture therefore produced `101.325` at the surface and `199.3888` at 10 m, while both message contracts define the pressure field in Pascals. The reported variance was likewise left in kPa² instead of Pa².

## Change

Convert only at the message boundary:

- pressure: kPa → Pa
- variance: kPa² → Pa²
- apply the same values to Gazebo and ROS outputs

The internal pressure/depth calculation and public topics are unchanged.

## Validation

The exact candidate source was compiled in the ARM64 DAVE environment with ROS 2 Lyrical and Gazebo Jetty, then loaded as a Gazebo system plugin in two static test models.

| Condition | Expected | ROS output | Gazebo output | Variance |
| --- | ---: | ---: | ---: | ---: |
| Surface (`z=0`) | 101325 Pa | 101325 Pa | 101325 Pa | 9000000 Pa² |
| 10 m depth (`z=-10`) | 199388.8 Pa | 199388.8 Pa | 199388.8 Pa | 9000000 Pa² |

Result: both conditions passed with exact ROS/Gazebo agreement.

Repository checks:

```bash
pre-commit run --all-files
# Passed

git diff --check
# Passed
```

## Scope

This PR fixes the serialized unit contract only. Existing depth-sign, configured-noise, saturation, update-rate, and frame-id behavior is intentionally left unchanged for separate review.

## Checklist

- [x] One sensor contract issue per PR
- [x] Exact candidate source compiled
- [x] Surface and 10 m runtime outputs verified
- [x] Gazebo and ROS outputs agree
- [x] Repository hooks passed
