### PR TITLE
Handle zero USBL noise deviation

### DIFF
--- a/gazebo/dave_gz_sensor_plugins/src/UsblTransponder.cc
+++ b/gazebo/dave_gz_sensor_plugins/src/UsblTransponder.cc
@@ -195,6 +195,11 @@ void UsblTransponder::Configure(
   if (_sdf->HasElement("sigma"))
   {
     this->dataPtr->m_noiseSigma = _sdf->Get<double>("sigma");
+    if (this->dataPtr->m_noiseSigma < 0.0)
+    {
+      gzwarn << "Negative USBL sigma is invalid; using deterministic sigma=0" << std::endl;
+      this->dataPtr->m_noiseSigma = 0.0;
+    }
   }
 
   // Get transceiver model name
@@ -257,19 +262,27 @@ void UsblTransponder::Configure(
 
 void UsblTransponder::sendLocation()
 {
-  // randomly generate from normal distribution for noise
-  std::random_device rd{};
-  std::mt19937 gen{rd()};
-  std::normal_distribution<> d(this->dataPtr->m_noiseMu, this->dataPtr->m_noiseSigma);
+  double noiseX = this->dataPtr->m_noiseMu;
+  double noiseY = this->dataPtr->m_noiseMu;
+  double noiseZ = this->dataPtr->m_noiseMu;
+  if (this->dataPtr->m_noiseSigma > 0.0)
+  {
+    std::random_device rd{};
+    std::mt19937 gen{rd()};
+    std::normal_distribution<> distribution(this->dataPtr->m_noiseMu, this->dataPtr->m_noiseSigma);
+    noiseX = distribution(gen);
+    noiseY = distribution(gen);
+    noiseZ = distribution(gen);
+  }
 
   gz::math::Pose3d pose = worldPose(this->dataPtr->linkEntity, *this->dataPtr->ecm);
   gz::math::Vector3<double> position = pose.Pos();
   auto pub_msg = gz::msgs::Vector3d();
   // std::cout << position.X() << " " << position.Y() << " "
   //           << position.Z() << std::endl;
-  pub_msg.set_x(position.X() + d(gen));
-  pub_msg.set_y(position.Y() + d(gen));
-  pub_msg.set_z(position.Z() + d(gen));
+  pub_msg.set_x(position.X() + noiseX);
+  pub_msg.set_y(position.Y() + noiseY);
+  pub_msg.set_z(position.Z() + noiseZ);
   this->dataPtr->m_globalPosPub.Publish(pub_msg);
 }
 


### PR DESCRIPTION
## Summary

Allow USBL transponders to use `sigma=0` as a deterministic noise configuration instead of constructing an invalid C++ normal distribution.

## Problem

The checked-in USBL tutorial configures both transponders with:

```xml
<mu>0</mu>
<sigma>0.0</sigma>
```

`UsblTransponder::sendLocation()` always constructed `std::normal_distribution` with that standard deviation. On the tested libstdc++ build, the distribution enforces `stddev > 0`, so the first ping aborted Gazebo:

```text
std::normal_distribution<...>::param_type: Assertion '_M_stddev > 0' failed.
```

The reproduced baseline exited with code 134 and returned no USBL locations.

## Change

- For `sigma=0`, use the configured mean as a deterministic per-axis offset without constructing `std::normal_distribution`.
- Preserve the existing random sampling path for `sigma>0`.
- Clamp a negative standard deviation to zero and emit a warning.

No topic names, interrogation routing, coordinate conversion, or positive-sigma sampling behavior is changed.

## Validation

The exact candidate source was compiled in the ARM64 DAVE environment with ROS 2 Lyrical and Gazebo Jetty.

The original two-transponder tutorial geometry was then run with `mu=0`, `sigma=0` and common interrogation:

| Check | Result |
| --- | --- |
| Gazebo remained alive after pings | PASS |
| Spherical responses | 6, IDs 1 and 2 |
| Cartesian responses | 6, IDs 1 and 2 |
| Unexpected IDs | 0 |
| Maximum Cartesian axis error | `6.13e-11 m` |
| Maximum spherical reconstruction error | `6.13e-11 m` |
| Assertion / SIGABRT | 0 |

A second run with `sigma=-1` also stayed alive, returned the same deterministic geometry, and emitted one warning for each of the two invalid transponders.

Repository checks:

```bash
pre-commit run --all-files
# Passed

git diff --check
# Passed
```

## Checklist

- [x] Reproduced the checked-in `sigma=0` crash
- [x] Exact candidate source compiled
- [x] Two-transponder runtime path verified
- [x] Non-positive sigma behavior verified
- [x] Repository hooks passed
