### PR TITLE
Add headless world launch option

### DIFF
--- a/examples/dave_demos/launch/dave_world.launch.py
+++ b/examples/dave_demos/launch/dave_world.launch.py
@@ -13,6 +13,7 @@ def launch_setup(context, *args, **kwargs):
 
     world_name = LaunchConfiguration("world_name").perform(context)
     verbose_flag = LaunchConfiguration("verbose").perform(context)
+    headless_flag = LaunchConfiguration("headless").perform(context)
     world_file_name = f"{world_name}.world"
 
     world_path = os.path.join(pkg_dave_worlds, "worlds", world_file_name)
@@ -21,6 +22,8 @@ def launch_setup(context, *args, **kwargs):
     gz_args = f"-r {world_path}"
     if verbose_flag.lower() == "true":
         gz_args += " --verbose"
+    if headless_flag.lower() == "true":
+        gz_args += " -s"
 
     gz_sim = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(os.path.join(pkg_ros_gz_sim, "launch", "gz_sim.launch.py")),
@@ -42,6 +45,11 @@ def generate_launch_description():
                 "verbose",
                 default_value="false",
                 description="Enable verbose mode for Gazebo simulation",
+            ),
+            DeclareLaunchArgument(
+                "headless",
+                default_value="false",
+                description="Run Gazebo server-only without the graphical client",
             ),
             OpaqueFunction(function=launch_setup),
         ]


### PR DESCRIPTION
## Summary

Add a `headless` argument to the standalone `dave_world.launch.py` entry point.

## Problem

DAVE's robot, sensor, and object launch files already accept `headless`, but the world-only launch exposed only `world_name` and `verbose`. A world therefore could not be started server-only through this entry point without bypassing the DAVE launch file.

Baseline `--show-args` output contained:

```text
world_name
verbose
```

## Change

- Declare `headless` with a default of `false`.
- Append Gazebo's `-s` server-only flag when `headless:=true`.
- Preserve the existing default launch behavior.

Example:

```bash
ros2 launch dave_demos dave_world.launch.py \
  world_name:=dave_ocean_waves headless:=true
```

## Validation

The exact candidate package was installed in the ARM64 DAVE environment with ROS 2 Lyrical and Gazebo Jetty.

A minimal test world was launched through the modified entry point:

```bash
ros2 launch dave_demos dave_world.launch.py \
  world_name:=pr58_headless headless:=true verbose:=true
```

Observed process:

```text
gz sim -r .../pr58_headless.world --verbose -s --force-version 10
```

Validation results:

- `headless` appears in `--show-args`: PASS
- `/world/pr58_headless/control` service became available: PASS
- Gazebo process received `-s`: PASS
- No Gazebo graphical client was started: PASS

Repository checks:

```bash
python3 -m py_compile examples/dave_demos/launch/dave_world.launch.py
# Passed

pre-commit run --all-files
# Passed

git diff --check
# Passed
```

## Checklist

- [x] Change is limited to the standalone world launch
- [x] Existing default remains unchanged
- [x] Exact candidate package installed
- [x] Server-only runtime path verified
- [x] Repository hooks passed
