### PR TITLE
Process USBL callbacks while paused

### DIFF
--- a/gazebo/dave_gz_sensor_plugins/src/UsblTransceiver.cc
+++ b/gazebo/dave_gz_sensor_plugins/src/UsblTransceiver.cc
@@ -600,10 +600,10 @@ void UsblTransceiver::calculateRelativePose(
 void UsblTransceiver::PostUpdate(
   const gz::sim::UpdateInfo & _info, const gz::sim::EntityComponentManager & _ecm)
 {
+  // ROS callbacks are wall-time events and must remain responsive while paused.
+  rclcpp::spin_some(this->ros_node_);
   if (!_info.paused)
   {
-    rclcpp::spin_some(this->ros_node_);
-
     if (!this->dataPtr->setGlobalMode)
     {
       std_msgs::msg::String mode;

--- a/gazebo/dave_gz_sensor_plugins/src/UsblTransponder.cc
+++ b/gazebo/dave_gz_sensor_plugins/src/UsblTransponder.cc
@@ -379,11 +379,8 @@ void UsblTransponder::commandRosCallback(const dave_interfaces::msg::UsblCommand
 void UsblTransponder::PostUpdate(
   const gz::sim::UpdateInfo & _info, const gz::sim::EntityComponentManager & _ecm)
 {
-  if (!_info.paused)
-  {
-    // gzdbg << "dave_gz_sensor_plugins::UsblTransponder::PostUpdate" << std::endl;
-    rclcpp::spin_some(this->ros_node_);
-  }
+  // ROS callbacks are wall-time events and must remain responsive while paused.
+  rclcpp::spin_some(this->ros_node_);
 }
 
 }  // namespace dave_gz_sensor_plugins


### PR DESCRIPTION
## Summary

Keep the USBL transceiver and transponder ROS callbacks responsive while Gazebo is paused.

## Problem

Both USBL plugins called `rclcpp::spin_some()` only when simulation time was advancing. In a paused world the ROS graph was present, but interrogation-mode updates and ping callbacks were never processed, so a common-interrogation request produced no spherical or Cartesian responses.

Baseline paused-world result:

- expected ROS publishers/subscribers present
- spherical responses: `0`
- Cartesian responses: `0`

ROS callbacks are wall-time events, so pausing Gazebo should not prevent the plugins from receiving commands.

## Change

- Spin the transceiver ROS node before the paused-state guard.
- Spin the transponder ROS node on every `PostUpdate` call.
- Keep the transceiver's automatic publication and simulation-time scheduler inside the existing unpaused branch.

This does not change the USBL topics, coordinate calculations, noise model, or automatic scheduling behavior.

## Validation

Built the exact changed sources in the ROS 2 Lyrical / Gazebo Jetty ARM64 environment and ran the two-transponder controlled world without `-r`.

- Gazebo stats confirmed `paused: true`
- common interrogation returned 6 spherical and 6 Cartesian samples
- response IDs were exactly `[1, 2]`
- no unexpected IDs
- maximum Cartesian axis error: `0.000174 m` with `sigma=0.0001`
- maximum spherical-to-Cartesian reconstruction error: `0.000174 m`
- Gazebo server remained alive after the matrix
- full repository pre-commit suite passed
