### PR TITLE
Forward DVL frame ID to ROS

### DIFF
--- a/gazebo/dave_ros_gz_plugins/src/DVLBridge.cc
+++ b/gazebo/dave_ros_gz_plugins/src/DVLBridge.cc
@@ -86,6 +86,21 @@ void DVLBridge::receiveGazeboCallback(const gz::msgs::DVLVelocityTracking & msg)
   auto dvl_msg = dave_interfaces::msg::DVL();
   dvl_msg.header.stamp.sec = msg.header().stamp().sec();
   dvl_msg.header.stamp.nanosec = msg.header().stamp().nsec();
+  for (int i = 0; i < msg.header().data_size(); ++i)
+  {
+    const auto & entry = msg.header().data(i);
+    if (entry.key() == "frame_id" && entry.value_size() > 0)
+    {
+      dvl_msg.header.frame_id = entry.value(0);
+      std::string::size_type pos = 0;
+      while ((pos = dvl_msg.header.frame_id.find("::", pos)) != std::string::npos)
+      {
+        dvl_msg.header.frame_id.replace(pos, 2, "/");
+        ++pos;
+      }
+      break;
+    }
+  }
 
   std::string dvl_type;
   std::string target_type;


### PR DESCRIPTION
## Summary

Forward the Gazebo DVL sensor frame into the custom ROS DVL message.

## Problem

The Gazebo `DVLVelocityTracking` message includes its sensor frame in `header.data["frame_id"]`, but `DVLBridge` copied only the timestamp. As a result, every ROS `dave_interfaces/msg/DVL` message had an empty `header.frame_id`, even though the source frame was known.

In the controlled DVL world, the baseline pair was:

- Gazebo: `nortek_dvl500_300::dvl500_base_link::nortek_dvl500_300`
- ROS: empty `frame_id`

An empty frame makes downstream TF-based interpretation of the measured velocity ambiguous.

## Change

Read the first non-empty `frame_id` entry from the Gazebo header and copy it to the ROS header. Gazebo's scoped-name delimiter (`::`) is converted to `/`, matching the standard `ros_gz_bridge` Gazebo-to-ROS header conversion.

No DVL velocity, range, covariance, beam, topic, or timestamp conversion is changed.

## Validation

Built the exact changed source in the ROS 2 Lyrical / Gazebo Jetty ARM64 environment and ran the controlled flat-bottom DVL world.

Across 10 consecutive ROS samples:

- Gazebo frame: `nortek_dvl500_300::dvl500_base_link::nortek_dvl500_300`
- ROS frame: `nortek_dvl500_300/dvl500_base_link/nortek_dvl500_300`
- all 10 messages retained four locked beams
- all 10 messages retained bottom-track mode
- Gazebo server remained alive after capture
- full repository pre-commit suite passed
