### PR TITLE
Clamp SeaPressure depth at the water surface

### DIFF
--- a/gazebo/dave_gz_sensor_plugins/src/sea_pressure_sensor.cc
+++ b/gazebo/dave_gz_sensor_plugins/src/sea_pressure_sensor.cc
@@ -1,5 +1,6 @@
 #include "dave_gz_sensor_plugins/sea_pressure_sensor.hh"
 #include <gz/msgs/fluid_pressure.pb.h>
+#include <algorithm>
 #include <chrono>
 #include <geometry_msgs/msg/point_stamped.hpp>
 #include <gz/math/Pose3.hh>
@@ -190,12 +191,9 @@ void SubseaPressureSensorPlugin::PreUpdate(
 {
   // Get model pose
   gz::math::Pose3d sea_pressure_sensor_pos = GetModelPose(this->dataPtr->modelEntity, _ecm);
-  double depth = std::abs(sea_pressure_sensor_pos.Z());
-  this->dataPtr->pressure = this->dataPtr->standardPressure;
-  if (depth >= 0)
-  {
-    this->dataPtr->pressure += depth * this->dataPtr->kPaPerM;
-  }
+  // DAVE worlds use ENU with the water surface at z=0.
+  const double depth = std::max(0.0, -sea_pressure_sensor_pos.Z());
+  this->dataPtr->pressure = this->dataPtr->standardPressure + depth * this->dataPtr->kPaPerM;
 
   // not adding gaussian noise for now, Future Work (TODO)
   // pressure += this->dataPtr->GetGaussianNoise(this->dataPtr->noiseAmp);


### PR DESCRIPTION
## Summary

Prevent the SeaPressure plugin from treating a model above the water surface as submerged.

## Problem

DAVE worlds use ENU coordinates with the water surface at `z=0`, but the plugin calculated depth with `abs(z)`. This made `z=+10 m` and `z=-10 m` produce the same pressure and inferred depth.

Baseline at `z=+10 m`:

- pressure: `199.3888` (the same value as 10 m underwater)
- inferred depth: `10 m`

Above-water altitude must not increase hydrostatic pressure.

## Change

Calculate depth as `max(0, -z)`:

- negative z remains submerged depth
- z=0 remains the surface
- positive z is clamped to zero depth

This PR changes only the depth sign/clamp logic. Message units are handled separately in #56.

## Validation

Built the exact changed source in the ROS 2 Lyrical / Gazebo Jetty ARM64 environment. Each case ran in a separate fresh server:

- `z=0 m`: `101.325`
- `z=-10 m`: `199.3888`
- `z=+10 m`: `101.325`
- all three servers remained alive after capture
- full repository pre-commit suite passed

The values above are the current branch's internal/output kPa scale; #56 independently converts the published message boundary to SI Pa.
