### PR TITLE
Honor SeaPressure update rate

### DIFF
--- a/gazebo/dave_gz_sensor_plugins/src/sea_pressure_sensor.cc
+++ b/gazebo/dave_gz_sensor_plugins/src/sea_pressure_sensor.cc
@@ -1,5 +1,6 @@
 #include "dave_gz_sensor_plugins/sea_pressure_sensor.hh"
 #include <gz/msgs/fluid_pressure.pb.h>
+#include <algorithm>
 #include <chrono>
 #include <geometry_msgs/msg/point_stamped.hpp>
 #include <gz/math/Pose3.hh>
@@ -34,6 +35,7 @@ public:
   double saturation;
   gz::sim::EntityComponentManager * ecm = nullptr;
   std::chrono::steady_clock::duration lastMeasurementTime{0};
+  bool hasMeasurement = false;
   bool estimateDepth;
   double standardPressure = 101.325;
   double kPaPerM = 9.80638;
@@ -46,6 +48,7 @@ public:
   std::string topic;
   double noiseAmp = 0.0;
   double noiseSigma = 3.0;
+  double updateRate = 0.0;
   double inferredDepth = 0.0;
   double pressure = 0.0;
   std::string modelName;
@@ -127,6 +130,11 @@ void SubseaPressureSensorPlugin::Configure(
   else
   {
     this->dataPtr->kPaPerM = 9.80638;
+  }
+
+  if (_sdf->HasElement("update_rate"))
+  {
+    this->dataPtr->updateRate = std::max(0.0, _sdf->Get<double>("update_rate"));
   }
 
   // this->dataPtr->gazeboNode->Init();
@@ -212,7 +220,20 @@ void SubseaPressureSensorPlugin::PreUpdate(
 void SubseaPressureSensorPlugin::PostUpdate(
   const gz::sim::UpdateInfo & _info, const gz::sim::EntityComponentManager & _ecm)
 {
+  if (this->dataPtr->hasMeasurement && this->dataPtr->updateRate > 0.0)
+  {
+    const auto period = std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+      std::chrono::duration<double>(1.0 / this->dataPtr->updateRate));
+    if (
+      _info.simTime >= this->dataPtr->lastMeasurementTime &&
+      _info.simTime - this->dataPtr->lastMeasurementTime < period)
+    {
+      return;
+    }
+  }
+
   this->dataPtr->lastMeasurementTime = _info.simTime;
+  this->dataPtr->hasMeasurement = true;
 
   // Publishing Sea_Pressure and depth estimate on gazebo topic
   gz::msgs::FluidPressure gzPressureMsg;


### PR DESCRIPTION
## Summary

Honor the SeaPressure plugin's configured `update_rate`.

## Problem

The REXROV and Slocum model descriptors configure the SeaPressure plugin with `<update_rate>10</update_rate>`, but the plugin never read that parameter and published once per physics iteration instead.

A controlled baseline with `<update_rate>2</update_rate>` and a 1 ms physics step produced messages every `0.001 s` (about 1000 Hz), not every `0.5 s`.

## Change

- Read and clamp the optional `update_rate` to a non-negative value.
- Use simulation time to gate pressure publication when the rate is positive.
- Preserve the existing unrestricted behavior when the parameter is absent or zero.
- Allow the first measurement immediately and handle simulation-time rewind by resetting on the next publication.

No pressure formula, message units, topic names, or depth calculation is changed.

## Validation

Built the exact changed source in the ROS 2 Lyrical / Gazebo Jetty ARM64 environment and ran a 1 ms controlled world with `<update_rate>2</update_rate>`.

Six consecutive message timestamps were:

`0.559, 1.059, 1.559, 2.059, 2.559, 3.059 s`

All five intervals were exactly `0.5 s`, and the Gazebo server remained alive after capture. The full repository pre-commit suite also passed.
