### PR TITLE
Validate object descriptors before spawning

### DIFF
--- a/models/dave_object_models/launch/upload_object.launch.py
+++ b/models/dave_object_models/launch/upload_object.launch.py
@@ -1,10 +1,28 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, RegisterEventHandler, LogInfo
+from launch.actions import DeclareLaunchArgument, RegisterEventHandler, LogInfo, OpaqueFunction
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch.conditions import IfCondition
 from launch_ros.substitutions import FindPackageShare
 from launch.event_handlers import OnProcessExit
 from launch_ros.actions import Node
+
+
+def validate_description(context, *args, **kwargs):
+    namespace = LaunchConfiguration("namespace").perform(context)
+    description_file = os.path.join(
+        get_package_share_directory("dave_object_models"),
+        "description",
+        namespace,
+        "model.sdf",
+    )
+    if not os.path.isfile(description_file):
+        raise FileNotFoundError(
+            f"Object descriptor does not exist for namespace [{namespace}]: " f"{description_file}"
+        )
+    return []
 
 
 def generate_launch_description():
@@ -134,4 +152,6 @@ def generate_launch_description():
         )
     ]
 
-    return LaunchDescription(args + nodes + event_handlers)
+    return LaunchDescription(
+        args + [OpaqueFunction(function=validate_description)] + nodes + event_handlers
+    )

--- a/models/dave_object_models/launch/upload_object.launch.py
+++ b/models/dave_object_models/launch/upload_object.launch.py
@@ -152,6 +152,9 @@ def generate_launch_description():
         )
     ]
 
-    return LaunchDescription(
-        args + [OpaqueFunction(function=validate_description)] + nodes + event_handlers
+    validate_object_description = OpaqueFunction(
+        function=validate_description,
+        condition=IfCondition(gui),
     )
+
+    return LaunchDescription(args + [validate_object_description] + nodes + event_handlers)

--- a/models/dave_object_models/package.xml
+++ b/models/dave_object_models/package.xml
@@ -6,6 +6,7 @@
   <maintainer email="rakeshvivek97@gmail.com">Rakesh Vivekanandan</maintainer>
   <license>Apache 2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>ament_index_python</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
     <!-- This doesn't work yet https://github.com/gazebosim/ros_gz/pull/492 -->


### PR DESCRIPTION
## Summary

Fail object uploads immediately when the requested model descriptor does not exist.

## Problem

`upload_object.launch.py` constructed the descriptor path lazily and started launch actions without checking it. A mistyped or unavailable namespace therefore failed later inside the spawn process, after launch had already begun, rather than identifying the missing DAVE descriptor at the boundary.

## Change

Add an `OpaqueFunction` preflight before any spawn node is started when simulation is enabled. It resolves:

`<dave_object_models share>/description/<namespace>/model.sdf`

and raises a `FileNotFoundError` containing both the namespace and resolved path when the descriptor is absent. The direct `ament_index_python` runtime dependency is declared in `package.xml`.

The preflight uses the same `gui` condition as the spawn node, so `gui:=false` keeps the existing no-spawn behavior. The spawn arguments and valid-object behavior are unchanged.

## Validation

Built and installed the exact changed package in the ROS 2 Lyrical / Gazebo Jetty ARM64 environment.

- valid `mossy_cinder_block` descriptor passed preflight
- valid object was created successfully in a fresh Gazebo server
- server remained alive after creation
- `definitely_missing_object` exited with code 1
- the missing case reported the namespace and full expected descriptor path
- no child process was started for the missing case
- `gui:=false` with a missing namespace exited successfully and started no process
- full repository pre-commit suite passed

