### PR TITLE
Fix Gazebo debug arguments in sensor launch

### DIFF
--- a/examples/dave_demos/launch/dave_sensor.launch.py
+++ b/examples/dave_demos/launch/dave_sensor.launch.py
@@ -38,7 +38,7 @@ def launch_setup(context, *args, **kwargs):
     if paused.perform(context) == "false":
         gz_args.append(" -r")
     if debug.perform(context) == "true":
-        gz_args.append(f"-v {verbosity_level.perform(context)}")
+        gz_args.append(f" -v {verbosity_level.perform(context)}")
 
     gz_sim_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(


### PR DESCRIPTION
## Summary

Keep the Gazebo verbosity flag separate from the unpause flag in `dave_sensor.launch.py`.

## Problem

The launch file builds `gz_args` by concatenating list entries. The `headless` and `paused` entries include a leading separator, but the debug entry did not. With:

`headless:=true paused:=false debug:=true verbosity_level:=4`

Gazebo was launched as:

`gz sim empty.sdf -s -r-v 4 --force-version 10`

The malformed `-r-v` option caused Gazebo to exit with code 109 before the sensor could be spawned.

## Change

Add the missing leading space to the verbosity argument so the command becomes:

`gz sim empty.sdf -s -r -v 4 --force-version 10`

No launch defaults or other argument semantics are changed.

## Validation

Built and installed the exact changed `dave_demos` package in the ROS 2 Lyrical / Gazebo Jetty ARM64 environment, then ran the same discriminating launch combination.

- process command contained the exact separate sequence `-s -r -v 4`
- Gazebo and the parent launch remained alive after the argument check
- no `process has died` event occurred
- full repository pre-commit suite passed
